### PR TITLE
Install config files as default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,8 +69,9 @@ AC_DEFINE_UNQUOTED(CONFIGDIR, "${configdir}",
 AC_SUBST(CONFIGDIR, "${configdir}")
 
 AC_ARG_ENABLE(configfiles, AC_HELP_STRING([--enable-configfiles],
-			[Do not install config files]),
-					[enable_configfiles=${enableval}])
+			[enable to install config files [default=yes]]),
+					[enable_configfiles=${enableval}],
+					[enable_configfiles=yes])
 AM_CONDITIONAL(CONFIGFILES, test "${enable_configfiles}" = "yes")
 
 AC_OUTPUT(Makefile)


### PR DESCRIPTION
This patch sets the default option --enable-configfiles to yes.

The configuration files main.conf and units.conf should be installed by default.